### PR TITLE
Add population information

### DIFF
--- a/population.csv
+++ b/population.csv
@@ -1,0 +1,22 @@
+Name,Short name,Code,Population
+Blekinge län,Blekinge,10,159606
+Dalarnas län,Dalarna,20,287966
+Gotlands län,Gotland,9,59686
+Gävleborgs län,Gävleborg,21,287382
+Hallands län,Halland,13,333848
+Jämtlands län,Jämtland,23,130810
+Jönköpings län,Jönköping,6,363599
+Kalmar län,Kalmar,8,245446
+Kronobergs län,Kronoberg,7,201469
+Norrbottens län,Norrbotten,25,250093
+Skåne län,Skåne,12,1377827
+Stockholms län,Stockholm,1,2377081
+Södermanlands län,Södermanland,4,297540
+Uppsala län,Uppsala,3,383713
+Värmlands län,Värmland,17,282414
+Västerbottens län,Västerbotten,24,271736
+Västernorrlands län,Västernorrland,22,245347
+Västmanlands län,Västmanland,19,275845
+Västra Götalands län,Västra Götaland,14,1725881
+Örebro län,Örebro,18,304805
+Östergötlands län,Östergötland,5,465495


### PR DESCRIPTION
This could be useful to display relative frequency instead of absolute numbers, for example in the map.

The population statistics are [taken directly from Statistics Sweden][source] (Statistiska Centralbyrån, SCB), for the end of 2019.

The CSV includes region name (Län), the short region name, [region code][iso-3166-2-se], and population.

[source]: https://www.scb.se/hitta-statistik/statistik-efter-amne/befolkning/befolkningens-sammansattning/befolkningsstatistik/pong/tabell-och-diagram/kvartals--och-halvarsstatistik--kommun-lan-och-riket/kvartal-4-2019/
[iso-3166-2-se]: https://sv.wikipedia.org/wiki/ISO_3166-2:SE